### PR TITLE
xrpchart.pyの53行目修正

### DIFF
--- a/app/xrpchart.py
+++ b/app/xrpchart.py
@@ -50,7 +50,6 @@ for exchange_id in EXCHANGE_LIST:
         plt.figure(1)
         plt.plot(x, bitbankxrp, label='bitbank(xrp/jpy)')
         plt.legend()#チャート名表示
-        plt.ylim([10, -10])#チャートのY軸の範囲(始めに取得した値に±10の値が今回のチャートの範囲 )
         plt.pause(.001)# チャート画面を表示
         plt.clf()
         time.sleep(FREQUENCY)


### PR DESCRIPTION
# issueのタイトル
[xrpchart.pyの修正]

# 技術的な実装詳細
- xrpchart.pyの53行目plt.ylim([10, -10])を削除した。
-これがあるとチャート目盛りが10から-10に固定されてしまい、価格が表示されなかったので削除しました。
# 実装課題
- 

# 新規ライブラリ導入の理由(メリット)・背景・ドキュメント等
- 

# リリース時の注意点
- 

# pylint実行時の点数
-9.71/10 

## 残っているエラーの詳細
-W: 26,19: Use of eval (eval-used)

# UI変更
## 変更前のキャプチャ

## 変更後のキャプチャ

## 動きがある場合(GIF動画など)

# その他・備考
-
