### PR TITLE
#39 modify-XRP/JPYのレートを引数で渡せるように変更。他微修正。モジュールの仕様がかなり変わったので対応をお願いします。

### DIFF
--- a/app/module/BitbankExchange.py
+++ b/app/module/BitbankExchange.py
@@ -4,33 +4,43 @@ Bitbankから取得したXRPをBTCに対応させるモジュールです
 #インポート
 import ccxt
 
-def exchangeXRP_BTC():
+def exchange_xrp_btc_bid(xrp_jpy_bid):
     '''
-    BitbankからXRP/JPY, JPY/BTCのオーダーブックを取得してXRP/BTCのASK, BID, スプレッドを計算するクラスです
+    XRP/JPYのbidを引数で受け取り、XRP/BTCのbidに変換して返すメソッドです
     '''
     #オーダーブック取得
     bitbank = ccxt.bitbank() #bitbankの情報を呼び出す
-    xrp_jpy_orderbook = bitbank.fetch_order_book('XRP/JPY') #XRP/JPYのオーダーブック取得
     btc_jpy_orderbook = bitbank.fetch_order_book('BTC/JPY') #BTC/JPYのオーダーブック取得
 
-    #ASKとBIDを取得
-    xrp_jpy_ask = xrp_jpy_orderbook['asks'][0][0] if (xrp_jpy_orderbook['asks']) else None #XRP/JPYのASK
-    xrp_jpy_bid = xrp_jpy_orderbook['bids'][0][0] if (xrp_jpy_orderbook['bids']) else None #XRP/JPYのBID
-    btc_jpy_ask = btc_jpy_orderbook['asks'][0][0] if (btc_jpy_orderbook['asks']) else None #BTC/JPYのASK
-    btc_jpy_bid = btc_jpy_orderbook['bids'][0][0] if (btc_jpy_orderbook['bids']) else None #BTC/JPYのBID
+    #BTC/JPYのASKを取得する
+    btc_jpy_ask = btc_jpy_orderbook['asks'][0][0] if (btc_jpy_orderbook['asks']) else None
 
-    #XRP/BTCのASK, BIDを計算する
-    xrp_btc_ask = xrp_jpy_ask / btc_jpy_bid if (xrp_jpy_ask and btc_jpy_bid) else None #XRP/BTCのASK
-    xrp_btc_bid = xrp_jpy_bid / btc_jpy_ask if (xrp_jpy_bid and btc_jpy_ask) else None #XRP/BTCのBID
+    #XRP/BTCのBIDを計算する
+    xrp_btc_bid = xrp_jpy_bid / btc_jpy_ask if (xrp_jpy_bid and btc_jpy_ask) else None
 
-    #XRP/BTCのスプレッドを計算する
-    xrp_btc_spread = (xrp_btc_ask - xrp_btc_bid) if (xrp_btc_ask and xrp_btc_bid) else None
+    #return
+    return xrp_btc_bid
 
-    #ASK, BID, スプレッドを返す
-    xrp_btc = {'bids':xrp_btc_bid, 'asks':xrp_btc_ask, 'spread':xrp_btc_spread} #ASK, BID, スプレッドを連想配列に入れる
-    return xrp_btc
+
+def exchange_xrp_btc_ask(xrp_jpy_ask):
+    '''
+    XRP/JPYのaskを引数で受け取り、XRP/BTCのaskに変換して返すメソッドです
+    '''
+    #オーダーブック取得
+    bitbank = ccxt.bitbank() #bitbankの情報を呼び出す
+    btc_jpy_orderbook = bitbank.fetch_order_book('BTC/JPY') #BTC/JPYのオーダーブック取得
+
+    #BTC/JPYのBIDを取得する
+    btc_jpy_bid = btc_jpy_orderbook['bids'][0][0] if (btc_jpy_orderbook['bids']) else None
+
+    #XRP/BTCのASKを計算する
+    xrp_btc_ask = xrp_jpy_ask / btc_jpy_bid if (xrp_jpy_ask and btc_jpy_bid) else None
+
+    #return
+    return xrp_btc_ask
 
 
 if __name__ == "__main__": #テスト用
-    print(exchangeXRP_BTC()) #xrp_btcの中身を表示する
-
+    #結果の表示
+    print(exchange_xrp_btc_bid(80))
+    print(exchange_xrp_btc_ask(80))


### PR DESCRIPTION
# issueのタイトル
[#39 作成したbtcに変換する機能の拡張]

# 技術的な実装詳細
- 変更への対応のためメソッドを分割し、引数を追加
- メソッド名を変更

# 実装課題
- BTC/JPYのレートを取得するモジュールが未完成のため、まだモジュール内でオーダーブックを取得せざるを得ない

# 新規ライブラリ導入の理由(メリット)・背景・ドキュメント等
- なし

# リリース時の注意点
- 

# pylint実行時の点数
- 9.38

## 残っているエラーの詳細
- Module name "BitbankExchange" doesn't conform to snake_case naming style (invalid-name)

# UI変更
## 変更前のキャプチャ

## 変更後のキャプチャ

## 動きがある場合(GIF動画など)

# その他・備考
- ほかのモジュールに与える影響がかなり大きい変更なので、対応をお願いします。
