### PR TITLE
exchanges.pyのbinance用のメソッドの返却値に日本円に変換した値を追加

### DIFF
--- a/app/module/exchanges.py
+++ b/app/module/exchanges.py
@@ -2,33 +2,31 @@
 # coding: UTF-8 文字コード指定
 import time
 import ccxt  # 取引所ライブラリをインポート
+from app import module
 
 BITBANK = ccxt.bitbank()  # 取引所の指定
+BINANCE = ccxt.binance()
 
-class Sample:
+
+class bitbank:
     """bitbankからの取引データを処理するクラス"""
-    def bitbank_id(self) -> " BITBANK取引所ID":
-        """取引所IDを返します"""
-        return BITBANK.id
-
     def bitbank(self):
         while True:
             try:
-                #bitbankのIDを取得
+                # bitbankのIDを取得
                 bitbnka_id = BITBANK.id
-                #biybankのXRP/JPYのオーダーブックの取得
+                # biybankのXRP/JPYのオーダーブックの取得
                 bitbank_orderbook = BITBANK.fetch_order_book('XRP/JPY')
-                #bitbank_orderbookからbidsの値を取得
+                # bitbank_orderbookからbidsの値を取得
                 bitbank_bid = bitbank_orderbook['bids'][0][0] \
                     if (bitbank_orderbook['bids']) else None
-                #bitbank_orderbookからasksの値を取得
+                # bitbank_orderbookからasksの値を取得
                 bitbank_ask = bitbank_orderbook['asks'][0][0] \
                     if (bitbank_orderbook['asks']) else None
-
-                orderbook = {'bitbank':{}, 'open_price':{}, 'high_price':{}}
+                orderbook = {'bitbank': {}, 'open_price': {}, 'high_price': {}}
                 orderbook['bitbank'] = {'bitbank_id': bitbnka_id}
-                orderbook['open_price'] = {bitbnka_id: bitbank_bid}
-                orderbook['high_price'] = {bitbnka_id: bitbank_ask}
+                orderbook['bid'] = {bitbnka_id: bitbank_bid}
+                orderbook['ask'] = {bitbnka_id: bitbank_ask}
                 return orderbook
             except ccxt.BaseError:
                 print("取引所から取引データを取得できません。")
@@ -36,6 +34,40 @@ class Sample:
                 time.sleep(10)
 
 
-CALLSAMPLEDATA = Sample()
-print(CALLSAMPLEDATA.bitbank())
+class BINANCEDATA:
+    """binanceからの取引データを処理するクラス"""
 
+    def returnbinancedata(self):
+        """binanceの取引データを返す"""
+        while True:
+            try:
+                # bitbankのIDを取得
+                binance_id = BINANCE.id
+                # biybankのXRP/JPYのオーダーブックの取得
+                binance_orderbook = BINANCE.fetch_order_book('XRP/BTC')
+                # bitbank_orderbookからbidsの値を取得
+                binance_bid = binance_orderbook['bids'][0][0] \
+                    if (binance_orderbook['bids']) else None
+                # bitbank_orderbookからasksの値を取得
+                binance_ask = binance_orderbook['asks'][0][0] \
+                    if (binance_orderbook['asks']) else None
+                # bitbank_orderbook_btcからbidsの値を取得
+                binance_bit_btc = module.btc_to_jpy.btc_to_jpy(binance_orderbook['bids'][0][0])
+                binance_ask_btc = module.btc_to_jpy.btc_to_jpy(binance_orderbook['asks'][0][0])
+
+                orderbook = {'binance': {}, 'bid': {}, 'ask': {},
+                             'bit_btc/jpy': {}, 'ask_btc/jpy': {}}
+                orderbook['binance'] = {'binance_id': binance_id}
+                orderbook['bid'] = {binance_id: binance_bid}
+                orderbook['ask'] = {binance_id: binance_ask}
+                orderbook['bit_btc/jpy'] = {binance_id: binance_bit_btc}
+                orderbook['ask_btc/jpy'] = {binance_id: binance_ask_btc}
+                return orderbook
+            except ccxt.BaseError:
+                print("取引所から取引データを取得できません。")
+                print("10秒待機してやり直します")
+                time.sleep(10)
+
+
+CALLSAMPLEDATA = BINANCEDATA()
+print(CALLSAMPLEDATA.returnbinancedata())


### PR DESCRIPTION
# issueのタイトル
[]

# 技術的な実装詳細
- 

# 実装課題
- 

# 新規ライブラリ導入の理由(メリット)・背景・ドキュメント等
- 

# リリース時の注意点
- 

# pylint実行時の点数
-exchanges.py(7.56/10 )

## 残っているエラーの詳細
-E:  5, 0: Unable to import 'app' (import-error)
C: 11, 0: Class name "bitbank" doesn't conform to PascalCase naming style (invalid-name)
C: 13, 4: Missing method docstring (missing-docstring)
R: 13, 4: Method could be a function (no-self-use)
R: 11, 0: Too few public methods (1/2) (too-few-public-methods)
R: 40, 4: Method could be a function (no-self-use)
R: 37, 0: Too few public methods (1/2) (too-few-public-methods)


# UI変更
## 変更前のキャプチャ

## 変更後のキャプチャ

## 動きがある場合(GIF動画など)

# その他・備考
-
