### PR TITLE
#81口座情報の取得クラスの作成

### DIFF
--- a/app/module/__init__.py
+++ b/app/module/__init__.py
@@ -1,0 +1,1 @@
+from . import bank_account

--- a/app/module/bank_account.py
+++ b/app/module/bank_account.py
@@ -13,71 +13,30 @@ class ACCOUNTINFORMATION:
         })
         return bitbanks
 
-
-    def get_info(key):
-        """口座残高の情報を返却する"""
-
+    def get_account_acquisition(self, getdata):
+        """getdataで指定された口座残高を返却する"""
         while True:
             try:
-                balance = key.fetch_balance()  # keyから残高を取得
-                print(key)
-                jsonstring = json.dumps(balance, indent=4)
-                print(jsonstring)
-                return balance
-            except ccxt.BaseError:
-                print("口座情報を取得できません。")
-                print("10秒待機してやり直します")
-                time.sleep(10)
-
-    def get_data_assets(key):
-        """資産情報を返却する"""
-
-        while True:
-            try:
-                balance = key.fetch_balance()  # keyから残高を取得
-                print(key)
-                jsonstring = json.dumps(balance, indent=4)
-                print(jsonstring)
-                return balance['info']['data'].get('assets')
-            except ccxt.BaseError:
-                print("口座情報を取得できません。")
-                print("10秒待機してやり直します")
-                time.sleep(10)
-
-    def get_data_asserts_jpy(key):
-        """JPYの資産情報を返却する"""
-
-        while True:
-            try:
-                balance = key.fetch_balance()  # keyから残高を取得
-                print(key)
-                return balance['info']['data']['assets'][0]
-            except ccxt.BaseError:
-                print("口座情報を取得できません。")
-                print("10秒待機してやり直します")
-                time.sleep(10)
-
-    def get_data_asserts_btc(key):
-        """BTCの資産情報を返却する"""
-
-        while True:
-            try:
-                balance = key.fetch_balance()  # keyから残高を取得
-                print(key)
-                return balance['info']['data']['assets'][1]
-            except ccxt.BaseError:
-                print("口座情報を取得できません。")
-                print("10秒待機してやり直します")
-                time.sleep(10)
-
-    def get_data_asserts_xrp(key):
-        """BTCの資産情報を返却する"""
-
-        while True:
-            try:
-                balance = key.fetch_balance()  # keyから残高を取得
-                print(key)
-                return balance['info']['data']['assets'][3]
+                balance = self.fetch_balance()  # selfから残高を取得
+                if (getdata == 'ALL'):
+                    # 全口座残高情報を返却する
+                    print(self)
+                    jsonstring = json.dumps(balance, indent=4)
+                    print(jsonstring)
+                    return balance
+                elif (getdata == 'assets'):
+                    # 全資産情報情報を返却する
+                    jsonstring = json.dumps(balance['info']['data'].get('assets'), indent=4)
+                    print(jsonstring)
+                    return balance['info']['data'].get(getdata)
+                elif (getdata == 0 or getdata == 1 or getdata == 3):
+                    # getdataの値が0の場合jpy、1の場合btc、3の場合xrpの資産情報を返却する。
+                    jsonstring = json.dumps(balance['info']['data']['assets'][getdata], indent=4)
+                    print(jsonstring)
+                    return balance['info']['data']['assets'][getdata]
+                else:
+                    # それ以外の場合Noneを返却する。
+                    return None
             except ccxt.BaseError:
                 print("口座情報を取得できません。")
                 print("10秒待機してやり直します")
@@ -95,11 +54,11 @@ class ACCOUNTINFORMATION:
                 time.sleep(10)
 
 if __name__ == "__main__":  # テスト用
-    print(ACCOUNTINFORMATION.get_info(ACCOUNTINFORMATION.get_private_api(0)))
-    print(ACCOUNTINFORMATION.get_data_assets(ACCOUNTINFORMATION.get_private_api(0)))
-    print(ACCOUNTINFORMATION.get_data_asserts_jpy(ACCOUNTINFORMATION.get_private_api(0)))
-    print(ACCOUNTINFORMATION.get_data_asserts_btc(ACCOUNTINFORMATION.get_private_api(0)))
-    print(ACCOUNTINFORMATION.get_data_asserts_xrp(ACCOUNTINFORMATION.get_private_api(0)))
+    print(ACCOUNTINFORMATION.get_account_acquisition(ACCOUNTINFORMATION.get_private_api(0), 'ALL'))
+    print(ACCOUNTINFORMATION.get_account_acquisition(ACCOUNTINFORMATION.get_private_api(0), 'assets'))
+    print(ACCOUNTINFORMATION.get_account_acquisition(ACCOUNTINFORMATION.get_private_api(0), 0))
+    print(ACCOUNTINFORMATION.get_account_acquisition(ACCOUNTINFORMATION.get_private_api(0), 1))
+    print(ACCOUNTINFORMATION.get_account_acquisition(ACCOUNTINFORMATION.get_private_api(0), 3))
     print(ACCOUNTINFORMATION.get_cryptocurrency_balance(ACCOUNTINFORMATION.get_private_api(0), 'JPY'))
     print(ACCOUNTINFORMATION.get_cryptocurrency_balance(ACCOUNTINFORMATION.get_private_api(0), 'XRP'))
     print(ACCOUNTINFORMATION.get_cryptocurrency_balance(ACCOUNTINFORMATION.get_private_api(0), 'BTC'))

--- a/app/module/bank_account.py
+++ b/app/module/bank_account.py
@@ -18,25 +18,28 @@ class ACCOUNTINFORMATION:
         while True:
             try:
                 balance = self.fetch_balance()  # selfから残高を取得
+                balancedata = None
                 if (getdata == 'ALL'):
                     # 全口座残高情報を返却する
                     print(self)
                     jsonstring = json.dumps(balance, indent=4)
                     print(jsonstring)
-                    return balance
+                    balancedata = balance
                 elif (getdata == 'assets'):
                     # 全資産情報情報を返却する
                     jsonstring = json.dumps(balance['info']['data'].get('assets'), indent=4)
                     print(jsonstring)
-                    return balance['info']['data'].get(getdata)
+                    balancedata = balance['info']['data'].get(getdata)
                 elif (getdata == 0 or getdata == 1 or getdata == 3):
                     # getdataの値が0の場合jpy、1の場合btc、3の場合xrpの資産情報を返却する。
                     jsonstring = json.dumps(balance['info']['data']['assets'][getdata], indent=4)
                     print(jsonstring)
-                    return balance['info']['data']['assets'][getdata]
+                    balancedata = balance['info']['data']['assets'][getdata]
                 else:
                     # それ以外の場合Noneを返却する。
-                    return None
+                    balancedata = None
+
+                return balancedata
             except ccxt.BaseError:
                 print("口座情報を取得できません。")
                 print("10秒待機してやり直します")

--- a/app/module/bank_account.py
+++ b/app/module/bank_account.py
@@ -54,11 +54,11 @@ class ACCOUNTINFORMATION:
                 time.sleep(10)
 
 if __name__ == "__main__":  # テスト用
-    print(ACCOUNTINFORMATION.get_account_acquisition(ACCOUNTINFORMATION.get_private_api(0), 'ALL'))
-    print(ACCOUNTINFORMATION.get_account_acquisition(ACCOUNTINFORMATION.get_private_api(0), 'assets'))
-    print(ACCOUNTINFORMATION.get_account_acquisition(ACCOUNTINFORMATION.get_private_api(0), 0))
-    print(ACCOUNTINFORMATION.get_account_acquisition(ACCOUNTINFORMATION.get_private_api(0), 1))
-    print(ACCOUNTINFORMATION.get_account_acquisition(ACCOUNTINFORMATION.get_private_api(0), 3))
+    print(ACCOUNTINFORMATION.get_account_balance(ACCOUNTINFORMATION.get_private_api(0), 'ALL'))
+    print(ACCOUNTINFORMATION.get_account_balance(ACCOUNTINFORMATION.get_private_api(0), 'assets'))
+    print(ACCOUNTINFORMATION.get_account_balance(ACCOUNTINFORMATION.get_private_api(0), 0))
+    print(ACCOUNTINFORMATION.get_account_balance(ACCOUNTINFORMATION.get_private_api(0), 1))
+    print(ACCOUNTINFORMATION.get_account_balance(ACCOUNTINFORMATION.get_private_api(0), 3))
     print(ACCOUNTINFORMATION.get_cryptocurrency_balance(ACCOUNTINFORMATION.get_private_api(0), 'JPY'))
     print(ACCOUNTINFORMATION.get_cryptocurrency_balance(ACCOUNTINFORMATION.get_private_api(0), 'XRP'))
     print(ACCOUNTINFORMATION.get_cryptocurrency_balance(ACCOUNTINFORMATION.get_private_api(0), 'BTC'))

--- a/app/module/bank_account.py
+++ b/app/module/bank_account.py
@@ -13,7 +13,7 @@ class ACCOUNTINFORMATION:
         })
         return bitbanks
 
-    def get_account_acquisition(self, getdata):
+    def get_account_balance(self, getdata):
         """getdataで指定された口座残高を返却する"""
         while True:
             try:

--- a/app/module/bank_account.py
+++ b/app/module/bank_account.py
@@ -83,41 +83,16 @@ class ACCOUNTINFORMATION:
                 print("10秒待機してやり直します")
                 time.sleep(10)
 
-
-    def get_jpy(key):
-        """JPY(日本円)の口座情報を返す"""
+    def get_cryptocurrency_balance(self, cryptocurrency):
+        """cryptocurrencyで指定された口座情報を返す"""
         while True:
             try:
-                balance = key.fetch_balance()  # keyから残高を取得
-                return balance['JPY']
+                balance = self.fetch_balance()  # selfから残高を取得
+                return balance[cryptocurrency]
             except ccxt.BaseError:
                 print("口座情報を取得できません。")
                 print("10秒待機してやり直します")
                 time.sleep(10)
-
-    def get_btc(key):
-        """BTC(ビットコイン)の口座情報を返す"""
-        while True:
-            try:
-                balance = key.fetch_balance()  # keyから残高を取得
-                return balance['BTC']
-            except ccxt.BaseError:
-                print("口座情報を取得できません。")
-                print("10秒待機してやり直します")
-                time.sleep(10)
-
-
-    def get_xrp(key):
-        """XRP(リップル)の口座情報を返す"""
-        while True:
-            try:
-                balance = key.fetch_balance()  # keyから残高を取得
-                return balance['XRP']
-            except ccxt.BaseError:
-                print("口座情報を取得できません。")
-                print("10秒待機してやり直します")
-                time.sleep(10)
-
 
 if __name__ == "__main__":  # テスト用
     print(ACCOUNTINFORMATION.get_info(ACCOUNTINFORMATION.get_private_api(0)))
@@ -125,6 +100,6 @@ if __name__ == "__main__":  # テスト用
     print(ACCOUNTINFORMATION.get_data_asserts_jpy(ACCOUNTINFORMATION.get_private_api(0)))
     print(ACCOUNTINFORMATION.get_data_asserts_btc(ACCOUNTINFORMATION.get_private_api(0)))
     print(ACCOUNTINFORMATION.get_data_asserts_xrp(ACCOUNTINFORMATION.get_private_api(0)))
-    print(ACCOUNTINFORMATION.get_jpy(ACCOUNTINFORMATION.get_private_api(0)))
-    print(ACCOUNTINFORMATION.get_btc(ACCOUNTINFORMATION.get_private_api(0)))
-    print(ACCOUNTINFORMATION.get_xrp(ACCOUNTINFORMATION.get_private_api(0)))
+    print(ACCOUNTINFORMATION.get_cryptocurrency_balance(ACCOUNTINFORMATION.get_private_api(0), 'JPY'))
+    print(ACCOUNTINFORMATION.get_cryptocurrency_balance(ACCOUNTINFORMATION.get_private_api(0), 'XRP'))
+    print(ACCOUNTINFORMATION.get_cryptocurrency_balance(ACCOUNTINFORMATION.get_private_api(0), 'BTC'))

--- a/app/module/bank_account.py
+++ b/app/module/bank_account.py
@@ -1,0 +1,130 @@
+import json
+import time
+import ccxt
+
+class ACCOUNTINFORMATION:
+    """口座情報を取得するクラス"""
+
+    def get_private_api(self):
+        """privateapiの情報を返す"""
+        bitbanks = ccxt.bitbank({
+            'apiKey': 'APIkey',
+            'secret': 'シークレットkey'
+        })
+        return bitbanks
+
+
+    def get_info(key):
+        """口座残高の情報を返却する"""
+
+        while True:
+            try:
+                balance = key.fetch_balance()  # keyから残高を取得
+                print(key)
+                jsonstring = json.dumps(balance, indent=4)
+                print(jsonstring)
+                return balance
+            except ccxt.BaseError:
+                print("口座情報を取得できません。")
+                print("10秒待機してやり直します")
+                time.sleep(10)
+
+    def get_data_assets(key):
+        """資産情報を返却する"""
+
+        while True:
+            try:
+                balance = key.fetch_balance()  # keyから残高を取得
+                print(key)
+                jsonstring = json.dumps(balance, indent=4)
+                print(jsonstring)
+                return balance['info']['data'].get('assets')
+            except ccxt.BaseError:
+                print("口座情報を取得できません。")
+                print("10秒待機してやり直します")
+                time.sleep(10)
+
+    def get_data_asserts_jpy(key):
+        """JPYの資産情報を返却する"""
+
+        while True:
+            try:
+                balance = key.fetch_balance()  # keyから残高を取得
+                print(key)
+                return balance['info']['data']['assets'][0]
+            except ccxt.BaseError:
+                print("口座情報を取得できません。")
+                print("10秒待機してやり直します")
+                time.sleep(10)
+
+    def get_data_asserts_btc(key):
+        """BTCの資産情報を返却する"""
+
+        while True:
+            try:
+                balance = key.fetch_balance()  # keyから残高を取得
+                print(key)
+                return balance['info']['data']['assets'][1]
+            except ccxt.BaseError:
+                print("口座情報を取得できません。")
+                print("10秒待機してやり直します")
+                time.sleep(10)
+
+    def get_data_asserts_xrp(key):
+        """BTCの資産情報を返却する"""
+
+        while True:
+            try:
+                balance = key.fetch_balance()  # keyから残高を取得
+                print(key)
+                return balance['info']['data']['assets'][3]
+            except ccxt.BaseError:
+                print("口座情報を取得できません。")
+                print("10秒待機してやり直します")
+                time.sleep(10)
+
+
+    def get_jpy(key):
+        """JPY(日本円)の口座情報を返す"""
+        while True:
+            try:
+                balance = key.fetch_balance()  # keyから残高を取得
+                return balance['JPY']
+            except ccxt.BaseError:
+                print("口座情報を取得できません。")
+                print("10秒待機してやり直します")
+                time.sleep(10)
+
+    def get_btc(key):
+        """BTC(ビットコイン)の口座情報を返す"""
+        while True:
+            try:
+                balance = key.fetch_balance()  # keyから残高を取得
+                return balance['BTC']
+            except ccxt.BaseError:
+                print("口座情報を取得できません。")
+                print("10秒待機してやり直します")
+                time.sleep(10)
+
+
+    def get_xrp(key):
+        """XRP(リップル)の口座情報を返す"""
+        while True:
+            try:
+                balance = key.fetch_balance()  # keyから残高を取得
+                return balance['XRP']
+            except ccxt.BaseError:
+                print("口座情報を取得できません。")
+                print("10秒待機してやり直します")
+                time.sleep(10)
+
+
+if __name__ == "__main__":  # テスト用
+    print(ACCOUNTINFORMATION.get_info(ACCOUNTINFORMATION.get_private_api(0)))
+    print(ACCOUNTINFORMATION.get_data_assets(ACCOUNTINFORMATION.get_private_api(0)))
+    print(ACCOUNTINFORMATION.get_data_asserts_jpy(ACCOUNTINFORMATION.get_private_api(0)))
+    print(ACCOUNTINFORMATION.get_data_asserts_btc(ACCOUNTINFORMATION.get_private_api(0)))
+    print(ACCOUNTINFORMATION.get_data_asserts_xrp(ACCOUNTINFORMATION.get_private_api(0)))
+    print(ACCOUNTINFORMATION.get_jpy(ACCOUNTINFORMATION.get_private_api(0)))
+    print(ACCOUNTINFORMATION.get_btc(ACCOUNTINFORMATION.get_private_api(0)))
+    print(ACCOUNTINFORMATION.get_xrp(ACCOUNTINFORMATION.get_private_api(0)))


### PR DESCRIPTION
# issueのタイトル
[#81]口座情報の取得

# 技術的な実装詳細
- 

# 実装課題
- 

# 新規ライブラリ導入の理由(メリット)・背景・ドキュメント等
- 

# リリース時の注意点
- 

# pylint実行時の点数
-　bank_account(1.44/10) 

## 残っているエラーの詳細
-No config file found, using default configuration
************* Module app.module.bank_account
C:130, 0: Final newline missing (missing-final-newline)
C:  1, 0: Missing module docstring (missing-docstring)
R:  8, 4: Method could be a function (no-self-use)
E: 17, 4: Method should have "self" as first argument (no-self-argument)
E: 22,26: Instance of 'ACCOUNTINFORMATION' has no 'fetch_balance' member (no-member)
E: 32, 4: Method should have "self" as first argument (no-self-argument)
E: 37,26: Instance of 'ACCOUNTINFORMATION' has no 'fetch_balance' member (no-member)
E: 47, 4: Method should have "self" as first argument (no-self-argument)
E: 52,26: Instance of 'ACCOUNTINFORMATION' has no 'fetch_balance' member (no-member)
E: 60, 4: Method should have "self" as first argument (no-self-argument)
E: 65,26: Instance of 'ACCOUNTINFORMATION' has no 'fetch_balance' member (no-member)
E: 73, 4: Method should have "self" as first argument (no-self-argument)
E: 78,26: Instance of 'ACCOUNTINFORMATION' has no 'fetch_balance' member (no-member)
E: 87, 4: Method should have "self" as first argument (no-self-argument)
E: 91,26: Instance of 'ACCOUNTINFORMATION' has no 'fetch_balance' member (no-member)
E: 98, 4: Method should have "self" as first argument (no-self-argument)
E:102,26: Instance of 'ACCOUNTINFORMATION' has no 'fetch_balance' member (no-member)
E:110, 4: Method should have "self" as first argument (no-self-argument)
E:114,26: Instance of 'ACCOUNTINFORMATION' has no 'fetch_balance' member (no-member)



# UI変更
## 変更前のキャプチャ

## 変更後のキャプチャ

## 動きがある場合(GIF動画など)

# その他・備考
-
