### PR TITLE
calculationから利益額表示+メイン下をスレッド化

### DIFF
--- a/app/main_menu.py
+++ b/app/main_menu.py
@@ -2,6 +2,7 @@
 import os  # パスを操作するモジュール
 import sys  # パスを読み込むモジュール
 import subprocess
+import threading
 
 sys.path.append(os.path.abspath(os.path.join('..')))  # 自作モジュールのパス指定
 # ライブラリ
@@ -16,6 +17,7 @@ import sqlite3  # DBへの追加時のエラーを取得する為
 #from app.module.sns import line
 #from app import xrpchart
 from app import graphcreation
+from app.module.exchangess import calculation
 
 import matplotlib
 
@@ -132,6 +134,43 @@ def main() -> None:
     exchangeD = ttk.Label(scrollframe, text=u"quoinex", font=PointFont)
     exchangeD.place(relx=0.1, rely=0.25)
 
+    #現在の売買最大値取得(XRP)
+    transaction = calculation.CALCULATION.difference_xrp_btc("")['max']
+    tara = ttk.Label(underframe, text="binanceで○○で購入しbitbankで□□で売り"+str(transaction)+"の利益です。", font=PointFont)
+    tara.place(relx=0.1, rely=0.05)
+
+    #現在の売買最大値取得(BTC)
+    ask_btc = ""
+    bid_btc = ""
+    btc_max = calculation.CALCULATION.difference_btc_xrp("")['max']
+    btc_value = calculation.CALCULATION.difference_btc_xrp("")['maxvalue']
+    #売買取引所の抽出
+    if(str(btc_max).startswith('bitbank')):
+        ask_btc = "bitbank"
+    elif(str(btc_max).startswith('binance')):
+        ask_btc = "binance"
+    elif(str(btc_max).startswith('coinex')):
+        ask_btc = "coinex"
+
+    if(str(btc_max).endswith('bitbank')):
+        bid_btc = "bitbank"
+    elif(str(btc_max)).endswith(('binance')):
+        bid_btc = "binance"
+    elif(str(btc_max)).endswith(('coinex')):
+        bid_btc = "coinex"
+
+    bmax = ttk.Label(underframe, text=ask_btc+str(btc_value)+bid_btc, font=PointFont)
+    bmax.place(relx=0.1, rely=0.1)
+
+    # 現在の売買最大値取得(BTC)
+    def func():
+        while True:
+            btc_value = calculation.CALCULATION.difference_btc_xrp("")['maxvalue']
+            thread = ttk.Label(underframe, text=btc_value, font=PointFont)
+            thread.place(relx=0.1, rely=0.12)
+            thread.update()
+            time.sleep(10)
+
     # underframe test
     history = ttk.Label(underframe, text=u"history", font=PointFont)
     history.place(relx=0.1, rely=0.02)
@@ -160,6 +199,10 @@ def main() -> None:
 
     linebutton.pack(side="left", expand=1, fill="both")
 
+    def create(self) :
+        grobal = graphcreation.GRAPHCREATION.create_graph_png(self)
+        return grobal
+
 
     def Getxrp() :
         graphcreation.GRAPHCREATION.create_graph_png("xrpjpy")
@@ -179,7 +222,7 @@ def main() -> None:
         exchangeD = ttk.Label(scrollframe, text=u"quoinex", font=PointFont)
         exchangeD.place(relx=0.1, rely=0.25)
         exchangeD.update()
-        # bitbankから現在価格取得
+        # bitbankからxrp価格取得
         exhanges, ask, bid = bitbank.BITBANK.currencyinformation('XRP')
         bitbank_ask = ttk.Label(scrollframe, text=ask, font=PointFont)
         bitbank_ask.place(relx=0.4, rely=0.15)
@@ -187,7 +230,7 @@ def main() -> None:
         bitbank_bid = ttk.Label(scrollframe, text=bid, font=PointFont)
         bitbank_bid.place(relx=0.7, rely=0.15)
         bitbank_bid.update()
-        # binanseから現在価格取得
+        # binanseから価格取得
         exchange2, ask2, bid2 = binance.BINANCE.currencyinformation('XRP')
         binance_ask = ttk.Label(scrollframe, text=ask2, font=PointFont)
         binance_ask.place(relx=0.4, rely=0.2)
@@ -235,7 +278,7 @@ def main() -> None:
         bitbank_bid.place(relx=0.7, rely=0.15)
         bitbank_bid.update()
         """
-        # binanseから現在価格取得
+        # binanseから現在価格取得 
         exchange2, ask2, bid2 = binance.BINANCE.currencyinformation('BTC')
         binance_ask = ttk.Label(scrollframe, text=ask2, font=PointFont)
         binance_ask.place(relx=0.4, rely=0.2)
@@ -658,6 +701,8 @@ def main() -> None:
 
     startpage.tkraise()
 
+    thread_1 = threading.Thread(target=func)
+    thread_1.start()
 
     # プログラムを始める
     window.mainloop()
@@ -665,3 +710,5 @@ def main() -> None:
 # メイン
 if __name__ == '__main__':
     main()
+    #thread_1 = threading.Thread(target=func)
+    #thread_1.start()

--- a/app/main_menu.py
+++ b/app/main_menu.py
@@ -14,9 +14,9 @@ from app.module.exchangess import bitbank
 from app.module.exchangess import binance
 from app.module.exchangess import quoinex
 #from app.module.sns import line
-#from app import xrpchart
 from app import graphcreation
 from app.module.exchangess import calculation
+import exchange_entry
 
 import matplotlib
 
@@ -92,7 +92,6 @@ def main() -> None:
 
     ordercanvas.create_window((0,0), window=orderframe, anchor=tkinter.NW, width=ordercanvas.cget('width'))
 
-    #button 300 furagu1010 =1310  zenntai 1500 heig 1000-furagu400button200 zenn 600
     undrpage = tkinter.Frame(startpage, width=1010, height=180, bd=15, relief="ridge", bg='black')
     undercanvas = tkinter.Canvas(undrpage, bg='black', width=960, height=125, relief="ridge")
 
@@ -163,10 +162,17 @@ def main() -> None:
             btc_value = lists['maxvalue']
             max_btc = lists['max_buy']
             min_btc = lists['min_sale']
-            thread = ttk.Label(underframe, text=str(ask_btc)+"で"+str(max_btc)+"円購入し"+str(bid_btc)+"で"+str(min_btc)+"円売却し"+str(btc_value)+"の利益です。", font=PointFont)
+            thread = ttk.Label(underframe, text=str(ask_btc)+"で"+str(max_btc)+"円購入し"+str(bid_btc)+"で"+str(min_btc)+"円売却し"+str(btc_value)+"円の利益です。", font=PointFont)
             thread.place(relx=0.1, rely=0.01 + float(count))
             thread.update()
             count =+ 0.03 * num
+
+            ask_transaction = ttk.Label(orderframe, text=str(ask_btc)+"        買        "+str(max_btc)+"     ", font=PointFont)
+            ask_transaction.place(relx=0.05, rely=0.02)
+            ask_transaction.update()
+            bid_transaction = ttk.Label(orderframe, text=str(bid_btc)+"        売        "+str(min_btc)+"     ", font=PointFont)
+            bid_transaction.place(relx=0.05, rely=0.07)
+            bid_transaction.update()
             time.sleep(20)
 
 
@@ -207,40 +213,37 @@ def main() -> None:
     #getfunc = tkinter.Button(underframe, text="TEST", width=7, font=PointFont, command=Func)
     getfunc.place(relx=0.0, rely=0.0)
 
+    #未実装
+    #funcstop = tkinter.Button(underframe, text=u'終了', width=7, font=PointFont, command=lambda: Getfunc.wait())
+    #funcstop.place(relx=0.0, rely=0.05)
 
-    funcstop = tkinter.Button(underframe, text=u'終了', width=7, font=PointFont, command=lambda: Getfunc.wait())
-    funcstop.place(relx=0.0, rely=0.05)
-
-    # orderframe test
-    ordertest =ttk.Label(orderframe, text=u'bitbank', font=PointFont)
-    ordertest.place(relx=0.1, rely=0.02)
 
     ### ボタン表示
     # APIキー登録ボタン生成
     startbutton = \
-        tkinter.Button(starttest, width=31, height=3, text="取引所設定", font=PointFont, command=lambda: changePage(mainPage))
+        tkinter.Button(starttest, width=47, height=3, text="取引所設定", font=PointFont, command=lambda: changePage(mainPage))
 
     # expand 親に合わせて変化　fill frameの空きスペースを埋めるか
     startbutton.pack(side="left", expand=1, fill="both")
 
     # 管理画面ボタン生成
     managementbutton = \
-        tkinter.Button(starttest, width=31, height=3, text=u'管理画面', font=PointFont,
+        tkinter.Button(starttest, width=46, height=3, text=u'管理画面', font=PointFont,
                        command=lambda: changePage(managementpage))
 
     managementbutton.pack(side='left', expand=1, fill="both")
 
     # SNSボタン生成
-    linebutton = \
-        tkinter.Button(starttest, width=31, height=3, text="通知設定", font=PointFont, command=lambda: changePage(snsPage))
+    #linebutton = \
+        #tkinter.Button(starttest, width=31, height=3, text="通知設定", font=PointFont, command=lambda: changePage(snsPage))
 
-    linebutton.pack(side="left", expand=1, fill="both")
+    #linebutton.pack(side="left", expand=1, fill="both")
 
     def create(self) :
         grobal = graphcreation.GRAPHCREATION.create_graph_png(self)
         return grobal
 
-    """
+
     def Getxrp() :
         graphcreation.GRAPHCREATION.create_graph_png("xrpjpy")
         xrpjpy = tkinter.PhotoImage(file='config/img/xrpjpycandlestick_week.png')
@@ -262,34 +265,34 @@ def main() -> None:
         exchangeD.update()
         # bitbankからxrp価格取得
         exhanges, ask, bid = bitbank.BITBANK.currencyinformation('XRP')
-        bitbank_ask = ttk.Label(scrollframe, text=ask, font=PointFont)
+        bitbank_ask = ttk.Label(scrollframe, text=str(ask)+"      ", font=PointFont)
         bitbank_ask.place(relx=0.4, rely=0.15)
         bitbank_ask.update()
-        bitbank_bid = ttk.Label(scrollframe, text=bid, font=PointFont)
+        bitbank_bid = ttk.Label(scrollframe, text=str(bid)+"      ", font=PointFont)
         bitbank_bid.place(relx=0.7, rely=0.15)
         bitbank_bid.update()
         # binanseから価格取得
         exchange2, ask2, bid2 = binance.BINANCE.currencyinformation('XRP')
-        binance_ask = ttk.Label(scrollframe, text=ask2, font=PointFont)
+        binance_ask = ttk.Label(scrollframe, text=str(ask2)+"     ", font=PointFont)
         binance_ask.place(relx=0.4, rely=0.2)
         binance_ask.update()
-        binance_bid = ttk.Label(scrollframe, text=bid2, font=PointFont)
+        binance_bid = ttk.Label(scrollframe, text=str(bid2)+"     ", font=PointFont)
         binance_bid.place(relx=0.7, rely=0.2)
         binance_bid.update()
         # quoinexから価格取得
         exchange2, ask2, bid2 = quoinex.Quoinex.currencyinformation('XRP')
-        quoinex_ask = ttk.Label(scrollframe, text=ask2, font=PointFont)
+        quoinex_ask = ttk.Label(scrollframe, text=str(ask2)+"     ", font=PointFont)
         quoinex_ask.place(relx=0.4, rely=0.25)
         quoinex_ask.update()
-        quoinex_bid = ttk.Label(scrollframe, text=bid2, font=PointFont)
+        quoinex_bid = ttk.Label(scrollframe, text=str(bid2)+"     ", font=PointFont)
         quoinex_bid.place(relx=0.7, rely=0.25)
         quoinex_bid.update()
         xrpchart = xrpchart.candlechart()
         print(xrpchart)
-        """
 
 
 
+    """
     def Getxrp():
         for num in range(1, 100):
             graphcreation.GRAPHCREATION.create_graph_png("xrpjpy")
@@ -336,11 +339,12 @@ def main() -> None:
             #xrpchart = xrpchart.candlechart()
             #print(xrpchart)
             time.sleep(10)
+            """
 
 
-    #xrp = tkinter.Button(backpage, text="XRP", width=7, font=PointFont, command=Getxrp)
-    xrpt = threading.Thread(target=Getxrp)
-    xrp = tkinter.Button(backpage, text="XRP", width=7, font=PointFont, command=lambda: xrpt.start())
+    xrp = tkinter.Button(backpage, text="XRP", width=10, font=PointFont, command=Getxrp)
+    #xrpt = threading.Thread(target=Getxrp)
+    #xrp = tkinter.Button(backpage, text="XRP", width=7, font=PointFont, command=lambda: xrpt.start())
     xrp.place(relx=0.0, rely=0.0)
 
 
@@ -383,10 +387,10 @@ def main() -> None:
         binance_bid.place(relx=0.7, rely=0.2)
         binance_bid.update()
         """
-        binance_ask = ttk.Label(scrollframe, text='0', font=PointFont)
+        binance_ask = ttk.Label(scrollframe, text='0            ', font=PointFont)
         binance_ask.place(relx=0.4, rely=0.2)
         binance_ask.update()
-        binance_bid = ttk.Label(scrollframe, text='0', font=PointFont)
+        binance_bid = ttk.Label(scrollframe, text='0            ', font=PointFont)
         binance_bid.place(relx=0.7, rely=0.2)
         binance_bid.update()
 
@@ -404,38 +408,8 @@ def main() -> None:
         xrpchart = xrpchart.candlechart()
         print(xrpchart)
 
-    bitbankbutton = tkinter.Button(backpage, text="BTC", font=PointFont, width=7, command=Getbtc)
-    bitbankbutton.place(relx=0.25, rely=0.0)
-
-    def Geteth() :
-        graphcreation.GRAPHCREATION.create_graph_png("ethjpy")
-        ethjpy = tkinter.PhotoImage(file='config/img/ethjpycandlestick_week.png')
-        # 画像更新
-        figure = tkinter.Canvas(tablepage, width=980, height=370)
-        figure.place(x=0, y=0)
-        figure.create_image(0, 0, image=ethjpy, anchor=tkinter.NW)
-        figure.update()
-
-        exchangeA = ttk.Label(scrollframe, text=u"bitbank", font=PointFont)
-        exchangeA.place(relx=0.1, rely=0.15)
-        exchangeA.update()
-        exchangeC = ttk.Label(scrollframe, text=u"          ", font=PointFont)
-        exchangeC.place(relx=0.1, rely=0.2)
-        exchangeC.update()
-        exchangeD = ttk.Label(scrollframe, text=u"          ", font=PointFont)
-        exchangeD.place(relx=0.1, rely=0.25)
-        exchangeD.update()
-        # bitbankから現在価格取得
-        exhanges, ask, bid = bitbank.BITBANK.currencyinformation('ETH')
-        bitbank_ask = ttk.Label(scrollframe, text=ask, font=PointFont)
-        bitbank_ask.place(relx=0.4, rely=0.15)
-        bitbank_ask.update()
-        bitbank_bid = ttk.Label(scrollframe, text=bid, font=PointFont)
-        bitbank_bid.place(relx=0.7, rely=0.15)
-        bitbank_bid.update()
-
-    eth = tkinter.Button(backpage, text="ETH", font=PointFont, width=7, command=Geteth)
-    eth.place(relx=0.5, rely=0.0)
+    bitbankbutton = tkinter.Button(backpage, text="BTC", font=PointFont, width=10, command=Getbtc)
+    bitbankbutton.place(relx=0.33, rely=0.0)
 
     def Getltc() :
         #グラフ生成、保存、表示
@@ -452,16 +426,24 @@ def main() -> None:
         exchangeC = ttk.Label(scrollframe, text=u"binance", font=PointFont)
         exchangeC.place(relx=0.1, rely=0.2)
         exchangeC.update()
-        exchangeD = ttk.Label(scrollframe, text=u"          ", font=PointFont)
+        exchangeD = ttk.Label(scrollframe, text=u"quoinex", font=PointFont)
         exchangeD.place(relx=0.1, rely=0.25)
         exchangeD.update()
 
         # bitbankから現在価格取得
+        """
         exhanges, ask, bid = bitbank.BITBANK.currencyinformation('LTC')
         bitbank_ask = ttk.Label(scrollframe, text=ask, font=PointFont)
         bitbank_ask.place(relx=0.4, rely=0.15)
         bitbank_ask.update()
         bitbank_bid = ttk.Label(scrollframe, text=bid, font=PointFont)
+        bitbank_bid.place(relx=0.7, rely=0.15)
+        bitbank_bid.update()
+        """
+        bitbank_ask = ttk.Label(scrollframe, text='0            ', font=PointFont)
+        bitbank_ask.place(relx=0.4, rely=0.15)
+        bitbank_ask.update()
+        bitbank_bid = ttk.Label(scrollframe, text='0            ', font=PointFont)
         bitbank_bid.place(relx=0.7, rely=0.15)
         bitbank_bid.update()
 
@@ -474,13 +456,16 @@ def main() -> None:
         binance_bid.place(relx=0.7, rely=0.2)
         binance_bid.update()
         # quoinexの値を空白に
-        quoinex_ask = ttk.Label(scrollframe, text=u"          ", font=PointFont)
+        quoinex_ask = ttk.Label(scrollframe, text='0            ', font=PointFont)
         quoinex_ask.place(relx=0.4, rely=0.25)
-        quoinex_bid = ttk.Label(scrollframe, text=u"          ", font=PointFont)
+        quoinex_bid = ttk.Label(scrollframe, text='0            ', font=PointFont)
         quoinex_bid.place(relx=0.7, rely=0.25)
+        xrpchart = xrpchart.candlechart()
+        print(xrpchart)
 
-    ltc = tkinter.Button(backpage, text="LTC", font=PointFont, width=7, command=Getltc)
-    ltc.place(relx=0.75, rely=0.0)
+
+    ltc = tkinter.Button(backpage, text="LTC", font=PointFont, width=10, command=Getltc)
+    ltc.place(relx=0.65, rely=0.0)
 
     exchange = ttk.Label(backpage, text=u"取引所", font=PointFont)
     exchange.place(relx=0.1, rely=0.12)
@@ -492,11 +477,11 @@ def main() -> None:
     orderpaint = ttk.Label(bidpage, text="         ", font=('', 84))
     orderpaint.place(relx=0.0, rely=0.0)
     orderexchange = ttk.Label(bidpage, text=u'取引所', font=PointFont)
-    orderexchange.place(relx=0.1, rely=0.1)
+    orderexchange.place(relx=0.05, rely=0.1)
     orderstatus = ttk.Label(bidpage, text=u'注文状態', font=PointFont)
-    orderstatus.place(relx=0.4, rely=0.1)
+    orderstatus.place(relx=0.3, rely=0.1)
     orderprice = ttk.Label(bidpage, text=u'注文価格', font=PointFont)
-    orderprice.place(relx=0.7, rely=0.1)
+    orderprice.place(relx=0.6, rely=0.1)
 
     #起動時重くなる為今はグラフ生成省略
     #graphcreation.GRAPHCREATION.create_graph_png("xrpjpy") #グラフ作成
@@ -531,6 +516,7 @@ def main() -> None:
 
     # -----------------------------------MainPage---------------------------------
     ### MainPage用のFrameを生成
+    """
     mainPage = tkinter.Frame(window)
 
     side = ("", 32)
@@ -564,13 +550,13 @@ def main() -> None:
     # snspageと同じように
     title = tkinter.Label(titlepage, text=u'')
     title.pack(fill='both', ipadx=550, ipady=30, side='left')
-    """
+    
     head = tkinter.Label(titlepage, text=u'API KEYS', foreground='white', background='gray', font=("", 40))
     head.place(relx=0.01, rely=0.01)
     content = tkinter.Label(titlepage, text=u'各取引所からAPIキーを取得してください。', foreground='white', background='gray',
                             font=("", 25))
     content.place(relx=0.15, rely=0.3)
-    """
+    
 
     exchange = tkinter.Label(mainpage, text=u'取引所', font=side, relief="groove")
     exchange.place(relx=0.1, rely=0.0, relheight=0.09, relwidth=0.2)
@@ -649,13 +635,16 @@ def main() -> None:
 
     # StartPageを上位層にする
     startpage.tkraise()
+    """
 
     # ----snsPage------------------------------------
 
-    # SNS登録のフレーム
-    snsPage = ttk.Frame(window)
+    # SNS(Mainに変更)登録のフレーム
+    mainPage = ttk.Frame(window)
 
-    all = tkinter.Frame(snsPage, width=1300, height=900)
+    side = ("", 32)
+
+    all = tkinter.Frame(mainPage, width=1300, height=900)
 
     allbar = tkinter.Canvas(all, width=1330, height=900)
 
@@ -679,66 +668,90 @@ def main() -> None:
 
     titlepage = tkinter.Frame(allframe, width=1300, height=250, bd=30, relief="groove")
     snspage = tkinter.Frame(allframe, width=1350, height=1000)
+    #ヘッダー部分
+    title = tkinter.Label(titlepage, text=u'取引所APIキー登録画面', font=side)
+    title.pack(fill='both', ipadx=300, ipady=25, side='left')
 
-    title = tkinter.Label(titlepage, text=u'')
-    title.pack(fill='both', ipadx=550, ipady=30, side='left')
 
-    #service = tkinter.Label(snspage, text=u"通知サービス              APIキー", font=side, relief="groove")
-    #service.place(relx=0.1, rely=0.0, relheight=0.1, relwidth=0.8, anchor=tkinter.NW)
-    service = tkinter.Label(snspage, text=u"通知サービス", font=side, relief="groove")
-    service.place(relx=0.1, rely=0.0, relheight=0.07, relwidth=0.3)
-    apikey = tkinter.Label(snspage, text=u"APIキー", font=side, relief="groove")
-    apikey.place(relx=0.4, rely=0.0, relheight=0.07, relwidth=0.3)
-    line = tkinter.Label(snspage, text=u"LINE", font=side, relief="groove")
-    line.place(relx=0.1, rely=0.07, relheight=0.1, relwidth=0.3)
+    service = tkinter.Label(snspage, text=u"取引所", font=side, relief="groove")
+    service.place(relx=0.1, rely=0.0, relheight=0.07, relwidth=0.25)
+    apikey = tkinter.Label(snspage, text=u"アクセスキー", font=side, relief="groove")
+    apikey.place(relx=0.35, rely=0.0, relheight=0.07, relwidth=0.25)
+    secretkey = tkinter.Label(snspage, text=u"シークレットキー", font=side, relief="groove")
+    secretkey.place(relx=0.6, rely=0.0,  relheight=0.07, relwidth=0.25)
+    line = tkinter.Label(snspage, text=u"BITBANK", font=side, relief="groove")
+    line.place(relx=0.1, rely=0.07, relheight=0.1, relwidth=0.25)
 
-    service = tkinter.Label(snspage, text=u"通知サービス", font=side, relief="groove")
-    service.place(relx=0.1, rely=0.2, relheight=0.07, relwidth=0.3)
-    apikey = tkinter.Label(snspage, text=u"APIキー", font=side, relief="groove")
-    apikey.place(relx=0.4, rely=0.2, relheight=0.07, relwidth=0.3)
-    slack = tkinter.Label(snspage, text=u"Slack", font=side, relief="groove")
-    slack.place(relx=0.1, rely=0.27, relheight=0.1, relwidth=0.3)
+    service = tkinter.Label(snspage, text=u"取引所", font=side, relief="groove")
+    service.place(relx=0.1, rely=0.2, relheight=0.07, relwidth=0.25)
+    apikey = tkinter.Label(snspage, text=u"アクセスキー", font=side, relief="groove")
+    apikey.place(relx=0.35, rely=0.2, relheight=0.07, relwidth=0.25)
+    secretkey = tkinter.Label(snspage, text=u"シークレットキー", font=side, relief="groove")
+    secretkey.place(relx=0.6, rely=0.2, relheight=0.07, relwidth=0.25)
+    slack = tkinter.Label(snspage, text=u"BINANCE", font=side, relief="groove")
+    slack.place(relx=0.1, rely=0.27, relheight=0.1, relwidth=0.25)
 
-    service = tkinter.Label(snspage, text=u"通知サービス", font=side, relief="ridge")
-    service.place(relx=0.1, rely=0.4, relheight=0.07, relwidth=0.3)
-    apikey = tkinter.Label(snspage, text=u"APIキー", font=side, relief="ridge")
-    apikey.place(relx=0.4, rely=0.4, relheight=0.07, relwidth=0.3)
-    sample = tkinter.Label(snspage, text=u"Sample", font=side, relief="ridge")
-    sample.place(relx=0.1, rely=0.47, relheight=0.1, relwidth=0.3)
+    service = tkinter.Label(snspage, text=u"取引所", font=side, relief="ridge")
+    service.place(relx=0.1, rely=0.4, relheight=0.07, relwidth=0.25)
+    apikey = tkinter.Label(snspage, text=u"アクセスキー", font=side, relief="ridge")
+    apikey.place(relx=0.35, rely=0.4, relheight=0.07, relwidth=0.25)
+    secretkey = tkinter.Label(snspage, text=u"シークレットキー", font=side, relief="groove")
+    secretkey.place(relx=0.6, rely=0.4, relheight=0.07, relwidth=0.25)
+    sample = tkinter.Label(snspage, text=u"QUOINEX", font=side, relief="ridge")
+    sample.place(relx=0.1, rely=0.47, relheight=0.1, relwidth=0.25)
 
 
     # エントリー (APIキーの入力)
-    line_token = tkinter.Entry(snspage, width=20, bd=20, font=("", 18), relief="flat")
-    line_token.place(relx=0.4, rely=0.075, relheight=0.1, relwidth=0.3)
+    bitbank_api = tkinter.Entry(snspage, width=20, bd=20, font=("", 18), relief="flat")
+    bitbank_api.place(relx=0.355, rely=0.07, relheight=0.1, relwidth=0.245)
+    bitbank_secret = tkinter.Entry(snspage, width=20, bd=20, font=("", 18), relief="flat")
+    bitbank_secret.place(relx=0.605, rely=0.07, relheight=0.1, relwidth=0.245)
 
-    slack_token = tkinter.Entry(snspage, width=20, bd=20, font=("", 18), relief="flat")
-    slack_token.place(relx=0.4, rely=0.27, relheight=0.1, relwidth=0.3)
 
-    slack_token = tkinter.Entry(snspage, width=20, bd=20, font=("", 18), relief="flat")
-    slack_token.place(relx=0.4, rely=0.47, relheight=0.1, relwidth=0.3)
+    binance_api = tkinter.Entry(snspage, width=20, bd=20, font=("", 18), relief="flat")
+    binance_api.place(relx=0.355, rely=0.27, relheight=0.1, relwidth=0.245)
+    binance_secret = tkinter.Entry(snspage, width=20, bd=20, font=("", 18), relief="flat")
+    binance_secret.place(relx=0.605, rely=0.27, relheight=0.1, relwidth=0.245)
 
-    def line_entry(self):
-        line_value = line_token.get()
-        # line.LINE.registration("LINE", line_value)
+    quoinex_api = tkinter.Entry(snspage, width=20, bd=20, font=("", 18), relief="flat")
+    quoinex_api.place(relx=0.355, rely=0.47, relheight=0.1, relwidth=0.245)
+    quoinex_secret = tkinter.Entry(snspage, width=20, bd=20, font=("", 18), relief="flat")
+    quoinex_secret.place(relx=0.605, rely=0.47, relheight=0.1, relwidth=0.245)
+
+    def bitbank_entry(self):
+        AK_value = bitbank_api.get()
+        CK_value = bitbank_secret.get()
+        exchange_entry.ENTRY.registration("1", AK_value, CK_value)
+
+    def binance_entry(self):
+        AK_value = binance_api.get()
+        CK_value = binance_secret.get()
+        exchange_entry.ENTRY.registration("2", AK_value, CK_value)
+
+
+    def quoinex_entry(self):
+        AK_value = quoinex_api.get()
+        CK_value = quoinex_secret.get()
+        exchange_entry.ENTRY.registration("3", AK_value, CK_value)
 
     button_line = tkinter.Button(snspage, text=u'登録', font=side, height=2, width=6)
-    button_line.place(relx=0.7, rely=0.07)
-    button_line.bind("<Button-1>", line_entry)
+    button_line.place(relx=0.855, rely=0.07)
+    button_line.bind("<Button-1>", bitbank_entry)
 
     button_slack = tkinter.Button(snspage, text=u'登録', font=side, height=2, width=6)
-    button_slack.place(relx=0.7, rely=0.27)
-    button_slack.bind("<Button-1>", line_entry)
+    button_slack.place(relx=0.855, rely=0.27)
+    button_slack.bind("<Button-1>", binance_entry)
 
     button_sample = tkinter.Button(snspage, text=u'登録', font=side, height=2, width=6)
-    button_sample.place(relx=0.7, rely=0.47)
-    button_sample.bind("<Button-1>", line_entry)
+    button_sample.place(relx=0.855, rely=0.47)
+    button_sample.bind("<Button-1>", quoinex_entry)
 
     line_button = tkinter.Button(snspage, width=30, height=1, text="  戻る  ",
-                                 command=lambda: changePage(startpage))
-    line_button.place(relx=0.4, rely=0.7)
+                                 command=lambda: changePage(startpage), font=("", 20))
+    line_button.place(relx=0.3, rely=0.7)
 
     # snsPageを配置
-    snsPage.grid(row=0, column=0, sticky="nsew")
+    mainPage.grid(row=0, column=0, sticky="nsew")
     all.place(relx=0.0, rely=0.0)
     titlepage.place(relx=0.1, rely=0.0)
     snspage.place(relx=0.01, rely=0.003)

--- a/app/main_menu.py
+++ b/app/main_menu.py
@@ -1,4 +1,3 @@
-"""メイン画面"""
 import os  # パスを操作するモジュール
 import sys  # パスを読み込むモジュール
 import subprocess
@@ -11,9 +10,9 @@ from tkinter import ttk
 import time  # 価格取得を繰り返す為
 import sqlite3  # DBへの追加時のエラーを取得する為
 
-#from app.module.exchangess import bitbank
-#from app.module.exchangess import binance
-#from app.module.exchangess import quoinex
+from app.module.exchangess import bitbank
+from app.module.exchangess import binance
+from app.module.exchangess import quoinex
 #from app.module.sns import line
 #from app import xrpchart
 from app import graphcreation
@@ -53,7 +52,7 @@ def main() -> None:
     #starttest = tkinter.Frame(startpage, height=200, width=300, relief="groove")
     starttest = tkinter.Frame(startpage, bg='black', width=300, height=200, bd=30, relief="groove")
     backpage = tkinter.Frame(startpage, bg='black', height=400, width=330, bd=10, relief="ridge")
-    badpage = tkinter.Frame(backpage, height=320, width=330, bg='white')
+    badpage = tkinter.Frame(backpage, height=320, width=300, bg='white')
     canvass = tkinter.Canvas(backpage, height=350, width=290, bg='gray')
 
     #スクロールバー生成
@@ -134,44 +133,14 @@ def main() -> None:
     exchangeD = ttk.Label(scrollframe, text=u"quoinex", font=PointFont)
     exchangeD.place(relx=0.1, rely=0.25)
 
-    #現在の売買最大値取得(XRP)
-    #transaction = calculation.CALCULATION.difference_xrp_btc("")['max']
-    tara = ttk.Label(underframe, text="binanceで○○で購入しbitbankで□□で売り"+"の利益です。", font=PointFont)
-    tara.place(relx=0.1, rely=0.05)
+    #tara = ttk.Label(underframe, text="binanceで○○で購入しbitbankで□□で売り"+"の利益です。", font=PointFont)
+    #tara.place(relx=0.1, rely=0.05)
 
-    #現在の売買最大値取得(BTC)
-    """
-    ask_btc = ""
-    bid_btc = ""
-    btc_max = calculation.CALCULATION.difference_btc_xrp(1)['max']
-    btc_value = calculation.CALCULATION.difference_btc_xrp(1)['maxvalue']
-    #buy = calculation.CALCULATION.difference_btc_xrp(1)['max_buy']
-    #sale = calculation.CALCULATION.difference_btc_xrp(1)['min_sale']
 
-    #売買取引所の抽出
-    if(str(btc_max).startswith('bitbank')):
-        ask_btc = "bitbank"
-    elif(str(btc_max).startswith('binance')):
-        ask_btc = "binance"
-    elif(str(btc_max).startswith('coinex')):
-        ask_btc = "coinex"
-
-    if(str(btc_max).endswith('bitbank')):
-        bid_btc = "bitbank"
-    elif(str(btc_max)).endswith(('binance')):
-        bid_btc = "binance"
-    elif(str(btc_max)).endswith(('coinex')):
-        bid_btc = "coinex"
-
-    bmax = ttk.Label(underframe, text=ask_btc+str(btc_value)+bid_btc, font=PointFont)
-    #bmax = ttk.Label(underframe, text=ask_btc+str(btc_value)+bid_btc+str(buy)+str(sale), font=PointFont)
-
-    bmax.place(relx=0.1, rely=0.1)
-    """
     # 現在の売買最大値取得(BTC)
     def func():
         count = 0.0
-        for num in range(1, 10):
+        for num in range(1, 1000):
             lists = calculation.CALCULATION.difference_btc_xrp(1)
             max_exchange = lists["max"]
             #利益売買取引所の抽出
@@ -198,18 +167,49 @@ def main() -> None:
             thread.place(relx=0.1, rely=0.01 + float(count))
             thread.update()
             count =+ 0.03 * num
-            time.sleep(30)
+            time.sleep(20)
+
+
+
     """
-    def func():
-        count = 0.0
-        while True:
-            btc_value = calculation.CALCULATION.difference_btc_xrp(1)['maxvalue']
-            thread = ttk.Label(underframe, text=btc_value, font=PointFont)
-            thread.place(relx=0.1, rely=0.01 + float(count))
-            thread.update()
-            count =+ 0.03
-            time.sleep(10)
-    """
+    def Func():
+        lists = calculation.CALCULATION.difference_btc_xrp(1)
+        max_exchange = lists["max"]
+        # 利益売買取引所の抽出
+        ask_btc = ""
+        bid_btc = ""
+        if (str(max_exchange).startswith('bitbank')):
+            ask_btc = "bitbank"
+        elif (str(max_exchange).startswith('binance')):
+            ask_btc = "binance"
+        elif (str(max_exchange).startswith('coinex')):
+            ask_btc = "coinex"
+
+        if (str(max_exchange).endswith('bitbank')):
+            bid_btc = "bitbank"
+        elif (str(max_exchange)).endswith(('binance')):
+            bid_btc = "binance"
+        elif (str(max_exchange)).endswith(('coinex')):
+            bid_btc = "coinex"
+        # 現在の最大利益取得
+        btc_value = lists['maxvalue']
+        max_btc = lists['max_buy']
+        min_btc = lists['min_sale']
+        thread = ttk.Label(underframe, text=str(ask_btc) + "で" + str(max_btc) + "円購入し" + str(bid_btc) + "で" + str(
+            min_btc) + "円売却し" + str(btc_value) + "の利益です。", font=PointFont)
+        thread.place(relx=0.1, rely=0.01)
+        thread.update()
+        # time.sleep(300)
+        """
+
+    Getfunc = threading.Thread(target=func)
+    getfunc = tkinter.Button(underframe, text=u"開始", width=7, font=PointFont, command=lambda: Getfunc.start())
+    #getfunc = tkinter.Button(underframe, text="TEST", width=7, font=PointFont, command=Func)
+    getfunc.place(relx=0.0, rely=0.0)
+
+
+    funcstop = tkinter.Button(underframe, text=u'終了', width=7, font=PointFont, command=lambda: Getfunc.wait())
+    funcstop.place(relx=0.0, rely=0.05)
 
     # orderframe test
     ordertest =ttk.Label(orderframe, text=u'bitbank', font=PointFont)
@@ -240,23 +240,24 @@ def main() -> None:
         grobal = graphcreation.GRAPHCREATION.create_graph_png(self)
         return grobal
 
-
+    """
     def Getxrp() :
         graphcreation.GRAPHCREATION.create_graph_png("xrpjpy")
         xrpjpy = tkinter.PhotoImage(file='config/img/xrpjpycandlestick_week.png')
-        #画像更新
+        # 画像更新
         figure = tkinter.Canvas(tablepage, width=950, height=370)
-        figure.place(x=0, y=0)
         figure.create_image(0, 0, image=xrpjpy, anchor=tkinter.NW)
+        figure.place(x=0, y=0)
+        # figure.create_image(0, 0, image=xrpjpy, anchor=tkinter.NW)
         figure.update()
 
-        exchangeA = ttk.Label(scrollframe, text=u"bitbank", font=PointFont)
+        exchangeA = ttk.Label(scrollframe, text=u"bitbank"+"  ", font=PointFont)
         exchangeA.place(relx=0.1, rely=0.15)
         exchangeA.update()
         exchangeC = ttk.Label(scrollframe, text=u"binance", font=PointFont)
         exchangeC.place(relx=0.1, rely=0.2)
         exchangeC.update()
-        exchangeD = ttk.Label(scrollframe, text=u"quoinex", font=PointFont)
+        exchangeD = ttk.Label(scrollframe, text=u"quoinex"+"  ", font=PointFont)
         exchangeD.place(relx=0.1, rely=0.25)
         exchangeD.update()
         # bitbankからxrp価格取得
@@ -283,10 +284,66 @@ def main() -> None:
         quoinex_bid = ttk.Label(scrollframe, text=bid2, font=PointFont)
         quoinex_bid.place(relx=0.7, rely=0.25)
         quoinex_bid.update()
+        xrpchart = xrpchart.candlechart()
+        print(xrpchart)
+        """
 
 
-    xrp = tkinter.Button(backpage, text="XRP", width=7, font=PointFont, command=Getxrp)
+
+    def Getxrp():
+        for num in range(1, 100):
+            graphcreation.GRAPHCREATION.create_graph_png("xrpjpy")
+            xrpjpy = tkinter.PhotoImage(file='config/img/xrpjpycandlestick_week.png')
+            # 画像更新
+            figure = tkinter.Canvas(tablepage, width=950, height=370)
+            figure.place(x=0, y=0)
+            figure.create_image(0, 0, image=xrpjpy, anchor=tkinter.NW)
+            figure.update()
+
+            exchangeA = ttk.Label(scrollframe, text=u"bitbank", font=PointFont)
+            exchangeA.place(relx=0.1, rely=0.15)
+            exchangeA.update()
+            exchangeC = ttk.Label(scrollframe, text=u"binance", font=PointFont)
+            exchangeC.place(relx=0.1, rely=0.2)
+            exchangeC.update()
+            exchangeD = ttk.Label(scrollframe, text=u"quoinex", font=PointFont)
+            exchangeD.place(relx=0.1, rely=0.25)
+            exchangeD.update()
+            # bitbankからxrp価格取得
+            exhanges, ask, bid = bitbank.BITBANK.currencyinformation('XRP')
+            bitbank_ask = ttk.Label(scrollframe, text=ask, font=PointFont)
+            bitbank_ask.place(relx=0.4, rely=0.15)
+            bitbank_ask.update()
+            bitbank_bid = ttk.Label(scrollframe, text=bid, font=PointFont)
+            bitbank_bid.place(relx=0.7, rely=0.15)
+            bitbank_bid.update()
+            # binanseから価格取得
+            exchange2, ask2, bid2 = binance.BINANCE.currencyinformation('XRP')
+            binance_ask = ttk.Label(scrollframe, text=ask2, font=PointFont)
+            binance_ask.place(relx=0.4, rely=0.2)
+            binance_ask.update()
+            binance_bid = ttk.Label(scrollframe, text=bid2, font=PointFont)
+            binance_bid.place(relx=0.7, rely=0.2)
+            binance_bid.update()
+            # quoinexから価格取得
+            exchange2, ask2, bid2 = quoinex.Quoinex.currencyinformation('XRP')
+            quoinex_ask = ttk.Label(scrollframe, text=ask2, font=PointFont)
+            quoinex_ask.place(relx=0.4, rely=0.25)
+            quoinex_ask.update()
+            quoinex_bid = ttk.Label(scrollframe, text=bid2, font=PointFont)
+            quoinex_bid.place(relx=0.7, rely=0.25)
+            quoinex_bid.update()
+            #xrpchart = xrpchart.candlechart()
+            #print(xrpchart)
+            time.sleep(10)
+
+
+    #xrp = tkinter.Button(backpage, text="XRP", width=7, font=PointFont, command=Getxrp)
+    xrpt = threading.Thread(target=Getxrp)
+    xrp = tkinter.Button(backpage, text="XRP", width=7, font=PointFont, command=lambda: xrpt.start())
     xrp.place(relx=0.0, rely=0.0)
+
+
 
     def Getbtc() :
         graphcreation.GRAPHCREATION.create_graph_png("btcjpy")
@@ -308,6 +365,8 @@ def main() -> None:
         exchangeD.update()
         # bitbankから現在価格取得
         exhanges, ask, bid = bitbank.BITBANK.currencyinformation('BTC')
+        ask = round(ask, 0)
+        bid = round(bid, 0)
         bitbank_ask = ttk.Label(scrollframe, text=ask, font=PointFont)
         bitbank_ask.place(relx=0.4, rely=0.15)
         bitbank_ask.update()
@@ -324,14 +383,26 @@ def main() -> None:
         binance_bid.place(relx=0.7, rely=0.2)
         binance_bid.update()
         """
+        binance_ask = ttk.Label(scrollframe, text='0', font=PointFont)
+        binance_ask.place(relx=0.4, rely=0.2)
+        binance_ask.update()
+        binance_bid = ttk.Label(scrollframe, text='0', font=PointFont)
+        binance_bid.place(relx=0.7, rely=0.2)
+        binance_bid.update()
+
+
         # quoinexから価格取得
         exchange3, ask3, bid3 = quoinex.Quoinex.currencyinformation('BTC')
+        ask3 = round(ask3, 0)
+        bid3 = round(bid3, 0)
         quoinex_ask = ttk.Label(scrollframe, text=ask3, font=PointFont)
         quoinex_ask.place(relx=0.4, rely=0.25)
         quoinex_ask.update()
         quoinex_bid = ttk.Label(scrollframe, text=bid3, font=PointFont)
         quoinex_bid.place(relx=0.7, rely=0.25)
         quoinex_bid.update()
+        xrpchart = xrpchart.candlechart()
+        print(xrpchart)
 
     bitbankbutton = tkinter.Button(backpage, text="BTC", font=PointFont, width=7, command=Getbtc)
     bitbankbutton.place(relx=0.25, rely=0.0)
@@ -384,7 +455,7 @@ def main() -> None:
         exchangeD = ttk.Label(scrollframe, text=u"          ", font=PointFont)
         exchangeD.place(relx=0.1, rely=0.25)
         exchangeD.update()
-        """
+
         # bitbankから現在価格取得
         exhanges, ask, bid = bitbank.BITBANK.currencyinformation('LTC')
         bitbank_ask = ttk.Label(scrollframe, text=ask, font=PointFont)
@@ -393,7 +464,7 @@ def main() -> None:
         bitbank_bid = ttk.Label(scrollframe, text=bid, font=PointFont)
         bitbank_bid.place(relx=0.7, rely=0.15)
         bitbank_bid.update()
-        """
+
         # binanseから現在価格取得
         exchange2, ask2, bid2 = binance.BINANCE.currencyinformation('LTC')
         binance_ask = ttk.Label(scrollframe, text=ask2, font=PointFont)
@@ -418,7 +489,7 @@ def main() -> None:
     ask = ttk.Label(backpage, text=u'売値', font=PointFont)
     ask.place(relx=0.7, rely=0.12)
 
-    orderpaint = ttk.Label(bidpage, text="        ", font=('', 100))
+    orderpaint = ttk.Label(bidpage, text="         ", font=('', 84))
     orderpaint.place(relx=0.0, rely=0.0)
     orderexchange = ttk.Label(bidpage, text=u'取引所', font=PointFont)
     orderexchange.place(relx=0.1, rely=0.1)
@@ -739,10 +810,9 @@ def main() -> None:
     startpage.tkraise()
 
     #スレッド要素
-    thread_1 = threading.Thread(target=func())
-    thread_1.start()
+    #thread_1 = threading.Thread(target=func())
+    #thread_1.start()
 
-    #threadd = threading.Thread(target=)
 
     # プログラムを始める
     window.mainloop()

--- a/app/main_menu.py
+++ b/app/main_menu.py
@@ -174,8 +174,27 @@ def main() -> None:
         for num in range(1, 10):
             lists = calculation.CALCULATION.difference_btc_xrp(1)
             max_exchange = lists["max"]
-            btc_value = calculation.CALCULATION.difference_btc_xrp(1)['maxvalue']
-            thread = ttk.Label(underframe, text=str(max_exchange)+"で購入し"+"で売却し"+str(btc_value)+"の利益です。", font=PointFont)
+            #利益売買取引所の抽出
+            ask_btc = ""
+            bid_btc = ""
+            if (str(max_exchange).startswith('bitbank')):
+                ask_btc = "bitbank"
+            elif (str(max_exchange).startswith('binance')):
+                ask_btc = "binance"
+            elif (str(max_exchange).startswith('coinex')):
+                ask_btc = "coinex"
+
+            if (str(max_exchange).endswith('bitbank')):
+                bid_btc = "bitbank"
+            elif (str(max_exchange)).endswith(('binance')):
+                bid_btc = "binance"
+            elif (str(max_exchange)).endswith(('coinex')):
+                bid_btc = "coinex"
+            #現在の最大利益取得
+            btc_value = lists['maxvalue']
+            max_btc = lists['max_buy']
+            min_btc = lists['min_sale']
+            thread = ttk.Label(underframe, text=str(ask_btc)+"で"+str(max_btc)+"円購入し"+str(bid_btc)+"で"+str(min_btc)+"円売却し"+str(btc_value)+"の利益です。", font=PointFont)
             thread.place(relx=0.1, rely=0.01 + float(count))
             thread.update()
             count =+ 0.03 * num

--- a/app/main_menu.py
+++ b/app/main_menu.py
@@ -135,15 +135,19 @@ def main() -> None:
     exchangeD.place(relx=0.1, rely=0.25)
 
     #現在の売買最大値取得(XRP)
-    transaction = calculation.CALCULATION.difference_xrp_btc("")['max']
-    tara = ttk.Label(underframe, text="binanceで○○で購入しbitbankで□□で売り"+str(transaction)+"の利益です。", font=PointFont)
+    #transaction = calculation.CALCULATION.difference_xrp_btc("")['max']
+    tara = ttk.Label(underframe, text="binanceで○○で購入しbitbankで□□で売り"+"の利益です。", font=PointFont)
     tara.place(relx=0.1, rely=0.05)
 
     #現在の売買最大値取得(BTC)
+    """
     ask_btc = ""
     bid_btc = ""
-    btc_max = calculation.CALCULATION.difference_btc_xrp("")['max']
-    btc_value = calculation.CALCULATION.difference_btc_xrp("")['maxvalue']
+    btc_max = calculation.CALCULATION.difference_btc_xrp(1)['max']
+    btc_value = calculation.CALCULATION.difference_btc_xrp(1)['maxvalue']
+    #buy = calculation.CALCULATION.difference_btc_xrp(1)['max_buy']
+    #sale = calculation.CALCULATION.difference_btc_xrp(1)['min_sale']
+
     #売買取引所の抽出
     if(str(btc_max).startswith('bitbank')):
         ask_btc = "bitbank"
@@ -160,21 +164,35 @@ def main() -> None:
         bid_btc = "coinex"
 
     bmax = ttk.Label(underframe, text=ask_btc+str(btc_value)+bid_btc, font=PointFont)
-    bmax.place(relx=0.1, rely=0.1)
+    #bmax = ttk.Label(underframe, text=ask_btc+str(btc_value)+bid_btc+str(buy)+str(sale), font=PointFont)
 
+    bmax.place(relx=0.1, rely=0.1)
+    """
     # 現在の売買最大値取得(BTC)
     def func():
-        while True:
-            btc_value = calculation.CALCULATION.difference_btc_xrp("")['maxvalue']
-            thread = ttk.Label(underframe, text=btc_value, font=PointFont)
-            thread.place(relx=0.1, rely=0.12)
+        count = 0.0
+        for num in range(1, 10):
+            lists = calculation.CALCULATION.difference_btc_xrp(1)
+            max_exchange = lists["max"]
+            btc_value = calculation.CALCULATION.difference_btc_xrp(1)['maxvalue']
+            thread = ttk.Label(underframe, text=str(max_exchange)+"で購入し"+"で売却し"+str(btc_value)+"の利益です。", font=PointFont)
+            thread.place(relx=0.1, rely=0.01 + float(count))
             thread.update()
+            count =+ 0.03 * num
+            time.sleep(30)
+    """
+    def func():
+        count = 0.0
+        while True:
+            btc_value = calculation.CALCULATION.difference_btc_xrp(1)['maxvalue']
+            thread = ttk.Label(underframe, text=btc_value, font=PointFont)
+            thread.place(relx=0.1, rely=0.01 + float(count))
+            thread.update()
+            count =+ 0.03
             time.sleep(10)
+    """
 
-    # underframe test
-    history = ttk.Label(underframe, text=u"history", font=PointFont)
-    history.place(relx=0.1, rely=0.02)
-
+    # orderframe test
     ordertest =ttk.Label(orderframe, text=u'bitbank', font=PointFont)
     ordertest.place(relx=0.1, rely=0.02)
 
@@ -701,8 +719,11 @@ def main() -> None:
 
     startpage.tkraise()
 
-    thread_1 = threading.Thread(target=func)
+    #スレッド要素
+    thread_1 = threading.Thread(target=func())
     thread_1.start()
+
+    #threadd = threading.Thread(target=)
 
     # プログラムを始める
     window.mainloop()


### PR DESCRIPTION
# issueのタイトル
[calculationから利益額表示+メイン下をスレッド化]

# 技術的な実装詳細
- 

# 実装課題
- 

# 新規ライブラリ導入の理由(メリット)・背景・ドキュメント等
- 

# リリース時の注意点
- 

# pylint実行時の点数
-

## 残っているエラーの詳細
-

# UI変更
## 変更前のキャプチャ
![2019_01_30 12_03_50](https://user-images.githubusercontent.com/25188566/52482654-32286200-2bf5-11e9-8e4f-0fbeb71e14cc.png)

## 変更後のキャプチャ
![2019_02_08 22_58_49](https://user-images.githubusercontent.com/25188566/52482645-2e94db00-2bf5-11e9-8815-1300dfd28ef5.png)

## 動きがある場合(GIF動画など)

# その他・備考
-
